### PR TITLE
Remove unnecessary `avif` type

### DIFF
--- a/configs/nginx-template.conf
+++ b/configs/nginx-template.conf
@@ -14,7 +14,6 @@ http {
   include mime.types;
   types {
     application/manifest+json webmanifest;
-    image/avif avif;
   }
   default_type application/octet-stream;
   charset_types application/javascript text/css application/manifest+json image/svg+xml;


### PR DESCRIPTION
Since this type is part of the default mime set in nginx: https://github.com/nginx/nginx/blob/6af8fe9cc44dbef43af4db5ea09d54ebd4aadbc5/conf/mime.types#L18

P.S. Honestly I stole your configs 🫶🏻